### PR TITLE
试验pdf转image的功能，调整pdf转图片的scale（清晰度）

### DIFF
--- a/certificate-generator/src/main/java/com/x/certificate/pdf/PdfConverter.java
+++ b/certificate-generator/src/main/java/com/x/certificate/pdf/PdfConverter.java
@@ -25,7 +25,7 @@ public class PdfConverter {
 				imagePathFile.mkdirs();
 			}
 			PDFRenderer pdfRender = new PDFRenderer(document);
-			BufferedImage image = pdfRender.renderImage(0, 200);
+			BufferedImage image = pdfRender.renderImage(0, 2);
 			out = new File(imagePath);
 			ImageIO.write(image, imageExt, out);
 			document.close();
@@ -50,8 +50,8 @@ public class PdfConverter {
 
 	public static void main(String[] args) throws IOException {
 		long startTime = System.currentTimeMillis();
-		String pdfPath = "C:\\Users\\a1579\\Desktop\\1.pdf";
-		String imagePath = "C:\\Users\\a1579\\Desktop\\1.jpg";
+		String pdfPath = "C:\\Users\\a1579\\Desktop\\custom.pdf";
+		String imagePath = "C:\\Users\\a1579\\Desktop\\custom.jpg";
 		toImageUsingPdfbox(pdfPath, imagePath, "jpg");
 		System.out.println("所用时间：" + (System.currentTimeMillis() - startTime) + "ms");
 	}

--- a/certificate-generator/src/main/resources/config/certificate.properties
+++ b/certificate-generator/src/main/resources/config/certificate.properties
@@ -3,3 +3,6 @@
 libreoffice.path=D:\\libreoffice
 
 certificate.image.suffix=jpg
+
+# pdf to image scale,default = 1 , recommended = 2
+certificate.image.scale=2


### PR DESCRIPTION
1.调整以证书pdf转图片功能可以正常使用；
2.示例证书pdf转image的scale最终设置为2（1 = 72DPI），在图片清晰度、图片大小、生成图片速度都比较合适